### PR TITLE
Add annotation for specifying a tool name

### DIFF
--- a/example/bookstore/v1/bookstore.pb.go
+++ b/example/bookstore/v1/bookstore.pb.go
@@ -3362,34 +3362,35 @@ const file_bookstore_v1_bookstore_proto_rawDesc = "" +
 	"extraPages\x12\x12\n" +
 	"\x04prop\x18\x04 \x01(\tR\x04prop\"=\n" +
 	"\x11ListBooksResponse\x12(\n" +
-	"\x05books\x18\x01 \x03(\v2\x12.bookstore.v1.BookR\x05books2\x85\r\n" +
-	"\x10BookstoreService\x12\x8d\x01\n" +
-	"\vListShelves\x12 .bookstore.v1.ListShelvesRequest\x1a!.bookstore.v1.ListShelvesResponse\"9ڜ\x045\n" +
-	"\fList Shelves\x12!List all shelves in the bookstore\x18\x01(\x01\x12\x8b\x01\n" +
-	"\vCreateShelf\x12 .bookstore.v1.CreateShelfRequest\x1a!.bookstore.v1.CreateShelfResponse\"7ڜ\x043\n" +
-	"\fCreate Shelf\x12#Create a new shelf in the bookstore\x12\x89\x01\n" +
-	"\vDeleteShelf\x12 .bookstore.v1.DeleteShelfRequest\x1a!.bookstore.v1.DeleteShelfResponse\"5ڜ\x041\n" +
-	"\fDelete Shelf\x12\x1fDelete a shelf in the bookstore \x01\x12\x86\x01\n" +
+	"\x05books\x18\x01 \x03(\v2\x12.bookstore.v1.BookR\x05books2\x95\x0e\n" +
+	"\x10BookstoreService\x12\x9b\x01\n" +
+	"\vListShelves\x12 .bookstore.v1.ListShelvesRequest\x1a!.bookstore.v1.ListShelvesResponse\"Gڜ\x04C\n" +
+	"\fList Shelves\x12!List all shelves in the bookstore\x18\x01(\x01:\flist_shelves\x12\x99\x01\n" +
+	"\vCreateShelf\x12 .bookstore.v1.CreateShelfRequest\x1a!.bookstore.v1.CreateShelfResponse\"Eڜ\x04A\n" +
+	"\fCreate Shelf\x12#Create a new shelf in the bookstore:\fcreate_shelf\x12\x97\x01\n" +
+	"\vDeleteShelf\x12 .bookstore.v1.DeleteShelfRequest\x1a!.bookstore.v1.DeleteShelfResponse\"Cڜ\x04?\n" +
+	"\fDelete Shelf\x12\x1fDelete a shelf in the bookstore \x01:\fdelete_shelf\x12\x93\x01\n" +
 	"\n" +
-	"ListGenres\x12\x1f.bookstore.v1.ListGenresRequest\x1a .bookstore.v1.ListGenresResponse\"5ڜ\x041\n" +
-	"\vList Genres\x12 List all genres in the bookstore\x18\x01\x12\x8b\x01\n" +
-	"\vCreateGenre\x12 .bookstore.v1.CreateGenreRequest\x1a!.bookstore.v1.CreateGenreResponse\"7ڜ\x043\n" +
-	"\fCreate Genre\x12#Create a new genre in the bookstore\x12x\n" +
-	"\bGetGenre\x12\x1d.bookstore.v1.GetGenreRequest\x1a\x1e.bookstore.v1.GetGenreResponse\"-ڜ\x04)\n" +
-	"\tGet Genre\x12\x1cGet a genre in the bookstore\x12\x89\x01\n" +
-	"\vDeleteGenre\x12 .bookstore.v1.DeleteGenreRequest\x1a!.bookstore.v1.DeleteGenreResponse\"5ڜ\x041\n" +
-	"\fDelete Genre\x12\x1fDelete a genre in the bookstore \x01\x12\x8c\x01\n" +
+	"ListGenres\x12\x1f.bookstore.v1.ListGenresRequest\x1a .bookstore.v1.ListGenresResponse\"Bڜ\x04>\n" +
+	"\vList Genres\x12 List all genres in the bookstore\x18\x01:\vlist_genres\x12\x99\x01\n" +
+	"\vCreateGenre\x12 .bookstore.v1.CreateGenreRequest\x1a!.bookstore.v1.CreateGenreResponse\"Eڜ\x04A\n" +
+	"\fCreate Genre\x12#Create a new genre in the bookstore:\fcreate_genre\x12\x83\x01\n" +
+	"\bGetGenre\x12\x1d.bookstore.v1.GetGenreRequest\x1a\x1e.bookstore.v1.GetGenreResponse\"8ڜ\x044\n" +
+	"\tGet Genre\x12\x1cGet a genre in the bookstore:\tget_genre\x12\x97\x01\n" +
+	"\vDeleteGenre\x12 .bookstore.v1.DeleteGenreRequest\x1a!.bookstore.v1.DeleteGenreResponse\"Cڜ\x04?\n" +
+	"\fDelete Genre\x12\x1fDelete a genre in the bookstore \x01:\fdelete_genre\x12\x99\x01\n" +
 	"\n" +
-	"CreateBook\x12\x1f.bookstore.v1.CreateBookRequest\x1a .bookstore.v1.CreateBookResponse\";ڜ\x047\n" +
-	"\vCreate Book\x12\"Create a new book in the bookstore \x01(\x010\x01\x12y\n" +
-	"\aGetBook\x12\x1c.bookstore.v1.GetBookRequest\x1a\x1d.bookstore.v1.GetBookResponse\"1ڜ\x04-\n" +
-	"\bGet Book\x12\x1bGet a book in the bookstore\x18\x01(\x010\x01\x12\x85\x01\n" +
-	"\tListBooks\x12\x1e.bookstore.v1.ListBooksRequest\x1a\x1f.bookstore.v1.ListBooksResponse\"7ڜ\x043\n" +
+	"CreateBook\x12\x1f.bookstore.v1.CreateBookRequest\x1a .bookstore.v1.CreateBookResponse\"Hڜ\x04D\n" +
+	"\vCreate Book\x12\"Create a new book in the bookstore \x01(\x010\x01:\vcreate_book\x12\x83\x01\n" +
+	"\aGetBook\x12\x1c.bookstore.v1.GetBookRequest\x1a\x1d.bookstore.v1.GetBookResponse\";ڜ\x047\n" +
+	"\bGet Book\x12\x1bGet a book in the bookstore\x18\x01(\x010\x01:\bget_book\x12\x91\x01\n" +
+	"\tListBooks\x12\x1e.bookstore.v1.ListBooksRequest\x1a\x1f.bookstore.v1.ListBooksResponse\"Cڜ\x04?\n" +
 	"\n" +
-	"List Books\x12\x1fList all books in the bookstore\x18\x01(\x010\x01\x12\x84\x01\n" +
+	"List Books\x12\x1fList all books in the bookstore\x18\x01(\x010\x01:\n" +
+	"list_books\x12\x91\x01\n" +
 	"\n" +
-	"DeleteBook\x12\x1f.bookstore.v1.DeleteBookRequest\x1a .bookstore.v1.DeleteBookResponse\"3ڜ\x04/\n" +
-	"\vDelete Book\x12\x1eDelete a book in the bookstore \x01\x12\x88\x01\n" +
+	"DeleteBook\x12\x1f.bookstore.v1.DeleteBookRequest\x1a .bookstore.v1.DeleteBookResponse\"@ڜ\x04<\n" +
+	"\vDelete Book\x12\x1eDelete a book in the bookstore \x01:\vdelete_book\x12\x88\x01\n" +
 	"\n" +
 	"UpdateBook\x12\x1f.bookstore.v1.UpdateBookRequest\x1a .bookstore.v1.UpdateBookResponse\"7ڜ\x043\n" +
 	"\vUpdate Book\x12\x1eUpdate a book in the bookstore \x01(\x010\x01\x1a\x06Ҝ\x04\x02\b\x01B\xb5\x01\n" +

--- a/example/bookstore/v1/bookstore.pb.mcpgw.go
+++ b/example/bookstore/v1/bookstore.pb.mcpgw.go
@@ -30,6 +30,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    true,
 			OpenWorldHint: false,
+			ToolName:      "list_shelves",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.CreateShelf",
@@ -42,6 +43,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			ToolName:      "create_shelf",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.DeleteShelf",
@@ -54,6 +56,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			ToolName:      "delete_shelf",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.ListGenres",
@@ -66,6 +69,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			ToolName:      "list_genres",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.CreateGenre",
@@ -78,6 +82,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			ToolName:      "create_genre",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.GetGenre",
@@ -90,6 +95,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			ToolName:      "get_genre",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.DeleteGenre",
@@ -102,6 +108,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			ToolName:      "delete_genre",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.CreateBook",
@@ -114,6 +121,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    true,
 			OpenWorldHint: true,
+			ToolName:      "create_book",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.GetBook",
@@ -126,6 +134,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    true,
 			OpenWorldHint: true,
+			ToolName:      "get_book",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.ListBooks",
@@ -138,6 +147,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    true,
 			OpenWorldHint: true,
+			ToolName:      "list_books",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.DeleteBook",
@@ -150,6 +160,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			ToolName:      "delete_book",
 		},
 		{
 			Method:        "bookstore.v1.BookstoreService.UpdateBook",
@@ -162,6 +173,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    true,
 			OpenWorldHint: true,
+			ToolName:      "bookstore_v1_bookstoreservice_updatebook",
 		},
 	},
 }

--- a/example/bookstore/v1/bookstore.proto
+++ b/example/bookstore/v1/bookstore.proto
@@ -21,6 +21,7 @@ service BookstoreService {
   rpc ListShelves(ListShelvesRequest) returns (ListShelvesResponse) {
     option (mcpgw.v1.method) = {
       title: "List Shelves"
+      tool_name: "list_shelves"
       description: "List all shelves in the bookstore"
       read_only_hint: true
       idempotent_hint: true
@@ -30,6 +31,7 @@ service BookstoreService {
   rpc CreateShelf(CreateShelfRequest) returns (CreateShelfResponse) {
     option (mcpgw.v1.method) = {
       title: "Create Shelf"
+      tool_name: "create_shelf"
       description: "Create a new shelf in the bookstore"
     };
   }
@@ -38,6 +40,7 @@ service BookstoreService {
   rpc DeleteShelf(DeleteShelfRequest) returns (DeleteShelfResponse) {
     option (mcpgw.v1.method) = {
       title: "Delete Shelf"
+      tool_name: "delete_shelf"
       description: "Delete a shelf in the bookstore"
       destructive_hint: true
     };
@@ -47,6 +50,7 @@ service BookstoreService {
   rpc ListGenres(ListGenresRequest) returns (ListGenresResponse) {
     option (mcpgw.v1.method) = {
       title: "List Genres"
+      tool_name: "list_genres"
       description: "List all genres in the bookstore"
       read_only_hint: true
     };
@@ -56,6 +60,7 @@ service BookstoreService {
   rpc CreateGenre(CreateGenreRequest) returns (CreateGenreResponse) {
     option (mcpgw.v1.method) = {
       title: "Create Genre"
+      tool_name: "create_genre"
       description: "Create a new genre in the bookstore"
     };
   }
@@ -64,6 +69,7 @@ service BookstoreService {
   rpc GetGenre(GetGenreRequest) returns (GetGenreResponse) {
     option (mcpgw.v1.method) = {
       title: "Get Genre"
+      tool_name: "get_genre"
       description: "Get a genre in the bookstore"
     };
   }
@@ -72,6 +78,7 @@ service BookstoreService {
   rpc DeleteGenre(DeleteGenreRequest) returns (DeleteGenreResponse) {
     option (mcpgw.v1.method) = {
       title: "Delete Genre"
+      tool_name: "delete_genre"
       description: "Delete a genre in the bookstore"
       destructive_hint: true
     };
@@ -81,6 +88,7 @@ service BookstoreService {
   rpc CreateBook(CreateBookRequest) returns (CreateBookResponse) {
     option (mcpgw.v1.method) = {
       title: "Create Book"
+      tool_name: "create_book"
       description: "Create a new book in the bookstore"
       destructive_hint: true
       idempotent_hint: true
@@ -92,6 +100,7 @@ service BookstoreService {
   rpc GetBook(GetBookRequest) returns (GetBookResponse) {
     option (mcpgw.v1.method) = {
       title: "Get Book"
+      tool_name: "get_book"
       description: "Get a book in the bookstore"
       read_only_hint: true
       idempotent_hint: true
@@ -101,6 +110,7 @@ service BookstoreService {
   rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
     option (mcpgw.v1.method) = {
       title: "List Books"
+      tool_name: "list_books"
       description: "List all books in the bookstore"
       read_only_hint: true
       idempotent_hint: true
@@ -111,6 +121,7 @@ service BookstoreService {
   rpc DeleteBook(DeleteBookRequest) returns (DeleteBookResponse) {
     option (mcpgw.v1.method) = {
       title: "Delete Book"
+      tool_name: "delete_book"
       description: "Delete a book in the bookstore"
       destructive_hint: true
     };

--- a/internal/mcpgw/mcpgw_methods.go
+++ b/internal/mcpgw/mcpgw_methods.go
@@ -39,15 +39,22 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 	ix.Protojson = true
 	ix.GRPC = true
 
+	methodName := strings.TrimPrefix(method.FullyQualifiedName(), ".")
+	toolName := mext.GetToolName()
+	if toolName == "" {
+		toolName = strings.ToLower(strings.ReplaceAll(methodName, ".", "_"))
+	}
+
 	rv := &methodTemplateContext{
 		MethodDesc: mcpgw_v1.MethodDesc{
-			Method:        strings.TrimPrefix(method.FullyQualifiedName(), "."),
+			Method:        methodName,
 			Title:         mext.GetTitle(),
 			Description:   mext.GetDescription(),
 			ReadOnlyHint:  mext.GetReadOnlyHint(),
 			Destructive:   mext.GetDestructiveHint(),
 			Idempotent:    mext.GetIdempotentHint(),
 			OpenWorldHint: mext.GetOpenWorldHint(),
+			ToolName:      toolName,
 		},
 		ServerName: ctx.ServerName(service).String(),
 		MethodName: ctx.Name(method).String(),

--- a/internal/mcpgw/templates/service.tmpl
+++ b/internal/mcpgw/templates/service.tmpl
@@ -19,6 +19,7 @@ var mcpgw_desc_{{- .ServerName -}} = mcpgw_v1.ServiceDesc{
             Destructive: {{ .Destructive -}},
             Idempotent: {{ .Idempotent -}},
             OpenWorldHint: {{ .OpenWorldHint -}},
+            ToolName: "{{ .ToolName -}}",
 		},
 		{{- end }}
 	},

--- a/mcpgw/v1/descriptor.go
+++ b/mcpgw/v1/descriptor.go
@@ -15,7 +15,7 @@ type ServiceDesc struct {
 
 type methodHandler func(srv interface{}, ctx context.Context, dec func(proto.Message) error, interceptor grpc.UnaryServerInterceptor) (proto.Message, error)
 type decoderHandler func(ctx context.Context, input DecoderInput, out proto.Message) error
-type inputSchemaHandler func() (map[string]any)
+type inputSchemaHandler func() map[string]any
 
 type MethodDesc struct {
 	Method        string
@@ -28,6 +28,7 @@ type MethodDesc struct {
 	Destructive   bool
 	Idempotent    bool
 	OpenWorldHint bool
+	ToolName      string
 }
 
 type ServiceRegistrar interface {

--- a/mcpgw/v1/mcpgw.pb.go
+++ b/mcpgw/v1/mcpgw.pb.go
@@ -151,6 +151,7 @@ type MethodOptions struct {
 	xxx_hidden_DestructiveHint bool                   `protobuf:"varint,4,opt,name=destructive_hint,json=destructiveHint"`
 	xxx_hidden_IdempotentHint  bool                   `protobuf:"varint,5,opt,name=idempotent_hint,json=idempotentHint"`
 	xxx_hidden_OpenWorldHint   bool                   `protobuf:"varint,6,opt,name=open_world_hint,json=openWorldHint"`
+	xxx_hidden_ToolName        *string                `protobuf:"bytes,7,opt,name=tool_name,json=toolName"`
 	XXX_raceDetectHookData     protoimpl.RaceDetectHookData
 	XXX_presence               [1]uint32
 	unknownFields              protoimpl.UnknownFields
@@ -230,34 +231,49 @@ func (x *MethodOptions) GetOpenWorldHint() bool {
 	return false
 }
 
+func (x *MethodOptions) GetToolName() string {
+	if x != nil {
+		if x.xxx_hidden_ToolName != nil {
+			return *x.xxx_hidden_ToolName
+		}
+		return ""
+	}
+	return ""
+}
+
 func (x *MethodOptions) SetTitle(v string) {
 	x.xxx_hidden_Title = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 7)
 }
 
 func (x *MethodOptions) SetDescription(v string) {
 	x.xxx_hidden_Description = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 7)
 }
 
 func (x *MethodOptions) SetReadOnlyHint(v bool) {
 	x.xxx_hidden_ReadOnlyHint = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 7)
 }
 
 func (x *MethodOptions) SetDestructiveHint(v bool) {
 	x.xxx_hidden_DestructiveHint = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 7)
 }
 
 func (x *MethodOptions) SetIdempotentHint(v bool) {
 	x.xxx_hidden_IdempotentHint = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 7)
 }
 
 func (x *MethodOptions) SetOpenWorldHint(v bool) {
 	x.xxx_hidden_OpenWorldHint = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 7)
+}
+
+func (x *MethodOptions) SetToolName(v string) {
+	x.xxx_hidden_ToolName = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 6, 7)
 }
 
 func (x *MethodOptions) HasTitle() bool {
@@ -302,6 +318,13 @@ func (x *MethodOptions) HasOpenWorldHint() bool {
 	return protoimpl.X.Present(&(x.XXX_presence[0]), 5)
 }
 
+func (x *MethodOptions) HasToolName() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 6)
+}
+
 func (x *MethodOptions) ClearTitle() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
 	x.xxx_hidden_Title = nil
@@ -332,6 +355,11 @@ func (x *MethodOptions) ClearOpenWorldHint() {
 	x.xxx_hidden_OpenWorldHint = false
 }
 
+func (x *MethodOptions) ClearToolName() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 6)
+	x.xxx_hidden_ToolName = nil
+}
+
 type MethodOptions_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -341,6 +369,7 @@ type MethodOptions_builder struct {
 	DestructiveHint *bool
 	IdempotentHint  *bool
 	OpenWorldHint   *bool
+	ToolName        *string
 }
 
 func (b0 MethodOptions_builder) Build() *MethodOptions {
@@ -348,28 +377,32 @@ func (b0 MethodOptions_builder) Build() *MethodOptions {
 	b, x := &b0, m0
 	_, _ = b, x
 	if b.Title != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 7)
 		x.xxx_hidden_Title = b.Title
 	}
 	if b.Description != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 7)
 		x.xxx_hidden_Description = b.Description
 	}
 	if b.ReadOnlyHint != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 7)
 		x.xxx_hidden_ReadOnlyHint = *b.ReadOnlyHint
 	}
 	if b.DestructiveHint != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 7)
 		x.xxx_hidden_DestructiveHint = *b.DestructiveHint
 	}
 	if b.IdempotentHint != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 7)
 		x.xxx_hidden_IdempotentHint = *b.IdempotentHint
 	}
 	if b.OpenWorldHint != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 7)
 		x.xxx_hidden_OpenWorldHint = *b.OpenWorldHint
+	}
+	if b.ToolName != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 6, 7)
+		x.xxx_hidden_ToolName = b.ToolName
 	}
 	return m0
 }
@@ -515,14 +548,15 @@ const file_mcpgw_v1_mcpgw_proto_rawDesc = "" +
 	"\x14mcpgw/v1/mcpgw.proto\x12\bmcpgw.v1\x1a google/protobuf/descriptor.proto\x1a!google/protobuf/go_features.proto\"\x10\n" +
 	"\x0eMessageOptions\"0\n" +
 	"\fFieldOptions\x12 \n" +
-	"\vdescription\x18\x01 \x01(\tR\vdescription\"\xe9\x01\n" +
+	"\vdescription\x18\x01 \x01(\tR\vdescription\"\x86\x02\n" +
 	"\rMethodOptions\x12\x14\n" +
 	"\x05title\x18\x01 \x01(\tR\x05title\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12$\n" +
 	"\x0eread_only_hint\x18\x03 \x01(\bR\freadOnlyHint\x12)\n" +
 	"\x10destructive_hint\x18\x04 \x01(\bR\x0fdestructiveHint\x12'\n" +
 	"\x0fidempotent_hint\x18\x05 \x01(\bR\x0eidempotentHint\x12&\n" +
-	"\x0fopen_world_hint\x18\x06 \x01(\bR\ropenWorldHint\"*\n" +
+	"\x0fopen_world_hint\x18\x06 \x01(\bR\ropenWorldHint\x12\x1b\n" +
+	"\ttool_name\x18\a \x01(\tR\btoolName\"*\n" +
 	"\x0eServiceOptions\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled:T\n" +
 	"\aservice\x12\x1f.google.protobuf.ServiceOptions\x18\xcaC \x01(\v2\x18.mcpgw.v1.ServiceOptionsR\aservice:P\n" +

--- a/protos/mcpgw/v1/mcpgw.proto
+++ b/protos/mcpgw/v1/mcpgw.proto
@@ -39,6 +39,7 @@ message MethodOptions {
   bool destructive_hint = 4;
   bool idempotent_hint = 5;
   bool open_world_hint = 6;
+  string tool_name = 7;
 }
 
 message ServiceOptions {


### PR DESCRIPTION
 If none is specified, derive it from the method fqdn.

Tool names must be 1-64 characters long, and satisfy this regex: `[a-zA-Z0-9_-]+`.

We could probably do more to ensure that a valid tool name is provided/generated, but I'm not sure what the failure mode should be in that case(fail to generate?)