### PR TITLE
Use the grpc generated full method name to identify methods

### DIFF
--- a/example/bookstore/v1/bookstore.pb.mcpgw.go
+++ b/example/bookstore/v1/bookstore.pb.mcpgw.go
@@ -20,7 +20,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 	HandlerType: (*BookstoreServiceServer)(nil),
 	Methods: []*mcpgw_v1.MethodDesc{
 		{
-			Method:        "bookstore.v1.BookstoreService.ListShelves",
+			Method:        BookstoreService_ListShelves_FullMethodName,
 			Handler:       _BookstoreService_ListShelves_MCPGW_Handler,
 			Decoder:       _BookstoreService_ListShelves_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_ListShelves_MCPGW_InputSchema,
@@ -32,7 +32,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: false,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.CreateShelf",
+			Method:        BookstoreService_CreateShelf_FullMethodName,
 			Handler:       _BookstoreService_CreateShelf_MCPGW_Handler,
 			Decoder:       _BookstoreService_CreateShelf_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_CreateShelf_MCPGW_InputSchema,
@@ -44,7 +44,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: false,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.DeleteShelf",
+			Method:        BookstoreService_DeleteShelf_FullMethodName,
 			Handler:       _BookstoreService_DeleteShelf_MCPGW_Handler,
 			Decoder:       _BookstoreService_DeleteShelf_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_DeleteShelf_MCPGW_InputSchema,
@@ -56,7 +56,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: false,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.ListGenres",
+			Method:        BookstoreService_ListGenres_FullMethodName,
 			Handler:       _BookstoreService_ListGenres_MCPGW_Handler,
 			Decoder:       _BookstoreService_ListGenres_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_ListGenres_MCPGW_InputSchema,
@@ -68,7 +68,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: false,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.CreateGenre",
+			Method:        BookstoreService_CreateGenre_FullMethodName,
 			Handler:       _BookstoreService_CreateGenre_MCPGW_Handler,
 			Decoder:       _BookstoreService_CreateGenre_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_CreateGenre_MCPGW_InputSchema,
@@ -80,7 +80,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: false,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.GetGenre",
+			Method:        BookstoreService_GetGenre_FullMethodName,
 			Handler:       _BookstoreService_GetGenre_MCPGW_Handler,
 			Decoder:       _BookstoreService_GetGenre_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_GetGenre_MCPGW_InputSchema,
@@ -92,7 +92,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: false,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.DeleteGenre",
+			Method:        BookstoreService_DeleteGenre_FullMethodName,
 			Handler:       _BookstoreService_DeleteGenre_MCPGW_Handler,
 			Decoder:       _BookstoreService_DeleteGenre_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_DeleteGenre_MCPGW_InputSchema,
@@ -104,7 +104,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: false,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.CreateBook",
+			Method:        BookstoreService_CreateBook_FullMethodName,
 			Handler:       _BookstoreService_CreateBook_MCPGW_Handler,
 			Decoder:       _BookstoreService_CreateBook_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_CreateBook_MCPGW_InputSchema,
@@ -116,7 +116,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: true,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.GetBook",
+			Method:        BookstoreService_GetBook_FullMethodName,
 			Handler:       _BookstoreService_GetBook_MCPGW_Handler,
 			Decoder:       _BookstoreService_GetBook_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_GetBook_MCPGW_InputSchema,
@@ -128,7 +128,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: true,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.ListBooks",
+			Method:        BookstoreService_ListBooks_FullMethodName,
 			Handler:       _BookstoreService_ListBooks_MCPGW_Handler,
 			Decoder:       _BookstoreService_ListBooks_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_ListBooks_MCPGW_InputSchema,
@@ -140,7 +140,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: true,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.DeleteBook",
+			Method:        BookstoreService_DeleteBook_FullMethodName,
 			Handler:       _BookstoreService_DeleteBook_MCPGW_Handler,
 			Decoder:       _BookstoreService_DeleteBook_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_DeleteBook_MCPGW_InputSchema,
@@ -152,7 +152,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			OpenWorldHint: false,
 		},
 		{
-			Method:        "bookstore.v1.BookstoreService.UpdateBook",
+			Method:        BookstoreService_UpdateBook_FullMethodName,
 			Handler:       _BookstoreService_UpdateBook_MCPGW_Handler,
 			Decoder:       _BookstoreService_UpdateBook_MCPGW_Decoder,
 			InputSchema:   _BookstoreService_UpdateBook_MCPGW_InputSchema,

--- a/example/bookstore/v1/bootstore_test.go
+++ b/example/bookstore/v1/bootstore_test.go
@@ -84,7 +84,7 @@ func TestInputSchemaValidation(t *testing.T) {
 	// Test the CreateGenre method's input schema
 	t.Run("CreateGenre_Schema", func(t *testing.T) {
 		// Get the method descriptor
-		methodDesc := mockRegistrar.methodDescs["bookstore.v1.BookstoreService.CreateGenre"]
+		methodDesc := mockRegistrar.methodDescs["/bookstore.v1.BookstoreService/CreateGenre"]
 		require.NotNil(t, methodDesc, "Method descriptor for CreateGenre should be registered")
 
 		// Check if the InputSchema function is available
@@ -120,7 +120,7 @@ func TestInputSchemaValidation(t *testing.T) {
 	// Test the CreateBook method's input schema which is more complex
 	t.Run("CreateBook_Schema", func(t *testing.T) {
 		// Get the method descriptor
-		methodDesc := mockRegistrar.methodDescs["bookstore.v1.BookstoreService.CreateBook"]
+		methodDesc := mockRegistrar.methodDescs["/bookstore.v1.BookstoreService/CreateBook"]
 		require.NotNil(t, methodDesc, "Method descriptor for CreateBook should be registered")
 
 		// Check if the InputSchema function is available
@@ -262,7 +262,7 @@ func TestMCPGWRegistration(t *testing.T) {
 	// Test CreateGenre method
 	t.Run("CreateGenre", func(t *testing.T) {
 		// Get the method descriptor for CreateGenre
-		methodDesc := mockRegistrar.methodDescs["bookstore.v1.BookstoreService.CreateGenre"]
+		methodDesc := mockRegistrar.methodDescs["/bookstore.v1.BookstoreService/CreateGenre"]
 		assert.NotNil(t, methodDesc, "Method descriptor for CreateGenre should be registered")
 
 		// Create input with map[string]any
@@ -284,7 +284,7 @@ func TestMCPGWRegistration(t *testing.T) {
 	// Test CreateBook method with nested structure
 	t.Run("CreateBook", func(t *testing.T) {
 		// Get the method descriptor for CreateBook
-		methodDesc := mockRegistrar.methodDescs["bookstore.v1.BookstoreService.CreateBook"]
+		methodDesc := mockRegistrar.methodDescs["/bookstore.v1.BookstoreService/CreateBook"]
 		assert.NotNil(t, methodDesc, "Method descriptor for CreateBook should be registered")
 
 		// Create complex input with nested map[string]any
@@ -321,7 +321,7 @@ func TestMCPGWRegistration(t *testing.T) {
 	// Test full end-to-end flow for CreateGenre
 	t.Run("CreateGenre_E2E", func(t *testing.T) {
 		// Get the method descriptor
-		methodDesc := mockRegistrar.methodDescs["bookstore.v1.BookstoreService.CreateGenre"]
+		methodDesc := mockRegistrar.methodDescs["/bookstore.v1.BookstoreService/CreateGenre"]
 
 		// Create context
 		ctx := context.Background()
@@ -332,7 +332,7 @@ func TestMCPGWRegistration(t *testing.T) {
 		}
 
 		// Create decoder input
-		input := NewMockDecoderInput("bookstore.v1.BookstoreService.CreateGenre", inputMap)
+		input := NewMockDecoderInput("/bookstore.v1.BookstoreService/CreateGenre", inputMap)
 
 		// Create a request message
 		req := &v1.CreateGenreRequest{}
@@ -393,7 +393,7 @@ func TestProtoValidateMiddleware(t *testing.T) {
 	v1.RegisterMCPBookstoreServiceServer(mockRegistrar, server)
 
 	// Get the method descriptor for CreateGenre
-	methodDesc := mockRegistrar.methodDescs["bookstore.v1.BookstoreService.CreateGenre"]
+	methodDesc := mockRegistrar.methodDescs["/bookstore.v1.BookstoreService/CreateGenre"]
 	assert.NotNil(t, methodDesc, "Method descriptor for CreateGenre should be registered")
 
 	// Create a validating interceptor
@@ -456,7 +456,7 @@ func TestProtoValidateMiddleware(t *testing.T) {
 	// If CreateBookRequest requires a title, test that validation
 	t.Run("InvalidBook_MissingTitle", func(t *testing.T) {
 		// Get the method descriptor for CreateBook
-		bookMethodDesc := mockRegistrar.methodDescs["bookstore.v1.BookstoreService.CreateBook"]
+		bookMethodDesc := mockRegistrar.methodDescs["/bookstore.v1.BookstoreService/CreateBook"]
 		assert.NotNil(t, bookMethodDesc, "Method descriptor for CreateBook should be registered")
 
 		// Create a map with invalid data (missing title which might be required)

--- a/internal/mcpgw/mcpgw_methods.go
+++ b/internal/mcpgw/mcpgw_methods.go
@@ -33,7 +33,7 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 	ix.MCPGWV1Schema = true
 
 	serviceShortName := strings.TrimSuffix(ctx.Name(service).String(), "Server")
-
+	methodFullName := fmt.Sprintf("%s_%s_FullMethodName", serviceShortName, ctx.Name(method).String())
 	ix.Context = true
 	ix.Proto = true
 	ix.Protojson = true
@@ -41,7 +41,7 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 
 	rv := &methodTemplateContext{
 		MethodDesc: mcpgw_v1.MethodDesc{
-			Method:        strings.TrimPrefix(method.FullyQualifiedName(), "."),
+			Method:        methodFullName,
 			Title:         mext.GetTitle(),
 			Description:   mext.GetDescription(),
 			ReadOnlyHint:  mext.GetReadOnlyHint(),
@@ -49,12 +49,9 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 			Idempotent:    mext.GetIdempotentHint(),
 			OpenWorldHint: mext.GetOpenWorldHint(),
 		},
-		ServerName: ctx.ServerName(service).String(),
-		MethodName: ctx.Name(method).String(),
-		FullMethodName: fmt.Sprintf("%s_%s_FullMethodName",
-			serviceShortName,
-			ctx.Name(method).String(),
-		),
+		ServerName:     ctx.ServerName(service).String(),
+		MethodName:     ctx.Name(method).String(),
+		FullMethodName: methodFullName,
 		MethodHandlerName: fmt.Sprintf("_%s_%s_MCPGW_Handler",
 			serviceShortName,
 			ctx.Name(method).String(),

--- a/internal/mcpgw/templates/service.tmpl
+++ b/internal/mcpgw/templates/service.tmpl
@@ -9,7 +9,7 @@ var mcpgw_desc_{{- .ServerName -}} = mcpgw_v1.ServiceDesc{
 	Methods: []*mcpgw_v1.MethodDesc{
 		{{- range .Methods }}
 		{
-			Method: "{{- .Method -}}",
+			Method: {{- .Method -}},
 			Handler: {{ .MethodHandlerName -}},
 			Decoder: {{ .DecoderHandlerName -}},
             InputSchema: {{ .InputSchemaHandlerName -}},


### PR DESCRIPTION
By using the generate full name, developers will be able to reference specific methods using the generated/exported variable from grpc.