### PR TITLE
Genereate references to the reflected types of each method's request and response types

### DIFF
--- a/example/bookstore/v1/bookstore.pb.mcpgw.go
+++ b/example/bookstore/v1/bookstore.pb.mcpgw.go
@@ -3,12 +3,41 @@ package v1
 
 import (
 	context "context"
+	reflect "reflect"
 
 	mcpgw_v1 "github.com/ductone/protoc-gen-mcpgw/mcpgw/v1"
 	mcpgw_schema "github.com/ductone/protoc-gen-mcpgw/mcpgw/v1/schema"
 	grpc "google.golang.org/grpc"
 	protojson "google.golang.org/protobuf/encoding/protojson"
 	proto "google.golang.org/protobuf/proto"
+)
+
+// Reflected request/response types for each method
+var (
+	_BookstoreService_ListShelves_RequestType  = reflect.TypeOf((*ListShelvesRequest)(nil)).Elem()
+	_BookstoreService_ListShelves_ResponseType = reflect.TypeOf((*ListShelvesResponse)(nil)).Elem()
+	_BookstoreService_CreateShelf_RequestType  = reflect.TypeOf((*CreateShelfRequest)(nil)).Elem()
+	_BookstoreService_CreateShelf_ResponseType = reflect.TypeOf((*CreateShelfResponse)(nil)).Elem()
+	_BookstoreService_DeleteShelf_RequestType  = reflect.TypeOf((*DeleteShelfRequest)(nil)).Elem()
+	_BookstoreService_DeleteShelf_ResponseType = reflect.TypeOf((*DeleteShelfResponse)(nil)).Elem()
+	_BookstoreService_ListGenres_RequestType   = reflect.TypeOf((*ListGenresRequest)(nil)).Elem()
+	_BookstoreService_ListGenres_ResponseType  = reflect.TypeOf((*ListGenresResponse)(nil)).Elem()
+	_BookstoreService_CreateGenre_RequestType  = reflect.TypeOf((*CreateGenreRequest)(nil)).Elem()
+	_BookstoreService_CreateGenre_ResponseType = reflect.TypeOf((*CreateGenreResponse)(nil)).Elem()
+	_BookstoreService_GetGenre_RequestType     = reflect.TypeOf((*GetGenreRequest)(nil)).Elem()
+	_BookstoreService_GetGenre_ResponseType    = reflect.TypeOf((*GetGenreResponse)(nil)).Elem()
+	_BookstoreService_DeleteGenre_RequestType  = reflect.TypeOf((*DeleteGenreRequest)(nil)).Elem()
+	_BookstoreService_DeleteGenre_ResponseType = reflect.TypeOf((*DeleteGenreResponse)(nil)).Elem()
+	_BookstoreService_CreateBook_RequestType   = reflect.TypeOf((*CreateBookRequest)(nil)).Elem()
+	_BookstoreService_CreateBook_ResponseType  = reflect.TypeOf((*CreateBookResponse)(nil)).Elem()
+	_BookstoreService_GetBook_RequestType      = reflect.TypeOf((*GetBookRequest)(nil)).Elem()
+	_BookstoreService_GetBook_ResponseType     = reflect.TypeOf((*GetBookResponse)(nil)).Elem()
+	_BookstoreService_ListBooks_RequestType    = reflect.TypeOf((*ListBooksRequest)(nil)).Elem()
+	_BookstoreService_ListBooks_ResponseType   = reflect.TypeOf((*ListBooksResponse)(nil)).Elem()
+	_BookstoreService_DeleteBook_RequestType   = reflect.TypeOf((*DeleteBookRequest)(nil)).Elem()
+	_BookstoreService_DeleteBook_ResponseType  = reflect.TypeOf((*DeleteBookResponse)(nil)).Elem()
+	_BookstoreService_UpdateBook_RequestType   = reflect.TypeOf((*UpdateBookRequest)(nil)).Elem()
+	_BookstoreService_UpdateBook_ResponseType  = reflect.TypeOf((*UpdateBookResponse)(nil)).Elem()
 )
 
 func RegisterMCPBookstoreServiceServer(s mcpgw_v1.ServiceRegistrar, srv BookstoreServiceServer) {
@@ -30,6 +59,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    true,
 			OpenWorldHint: false,
+			RequestType:   _BookstoreService_ListShelves_RequestType,
+			ResponseType:  _BookstoreService_ListShelves_ResponseType,
 		},
 		{
 			Method:        BookstoreService_CreateShelf_FullMethodName,
@@ -42,6 +73,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			RequestType:   _BookstoreService_CreateShelf_RequestType,
+			ResponseType:  _BookstoreService_CreateShelf_ResponseType,
 		},
 		{
 			Method:        BookstoreService_DeleteShelf_FullMethodName,
@@ -54,6 +87,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			RequestType:   _BookstoreService_DeleteShelf_RequestType,
+			ResponseType:  _BookstoreService_DeleteShelf_ResponseType,
 		},
 		{
 			Method:        BookstoreService_ListGenres_FullMethodName,
@@ -66,6 +101,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			RequestType:   _BookstoreService_ListGenres_RequestType,
+			ResponseType:  _BookstoreService_ListGenres_ResponseType,
 		},
 		{
 			Method:        BookstoreService_CreateGenre_FullMethodName,
@@ -78,6 +115,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			RequestType:   _BookstoreService_CreateGenre_RequestType,
+			ResponseType:  _BookstoreService_CreateGenre_ResponseType,
 		},
 		{
 			Method:        BookstoreService_GetGenre_FullMethodName,
@@ -90,6 +129,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			RequestType:   _BookstoreService_GetGenre_RequestType,
+			ResponseType:  _BookstoreService_GetGenre_ResponseType,
 		},
 		{
 			Method:        BookstoreService_DeleteGenre_FullMethodName,
@@ -102,6 +143,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			RequestType:   _BookstoreService_DeleteGenre_RequestType,
+			ResponseType:  _BookstoreService_DeleteGenre_ResponseType,
 		},
 		{
 			Method:        BookstoreService_CreateBook_FullMethodName,
@@ -114,6 +157,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    true,
 			OpenWorldHint: true,
+			RequestType:   _BookstoreService_CreateBook_RequestType,
+			ResponseType:  _BookstoreService_CreateBook_ResponseType,
 		},
 		{
 			Method:        BookstoreService_GetBook_FullMethodName,
@@ -126,6 +171,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    true,
 			OpenWorldHint: true,
+			RequestType:   _BookstoreService_GetBook_RequestType,
+			ResponseType:  _BookstoreService_GetBook_ResponseType,
 		},
 		{
 			Method:        BookstoreService_ListBooks_FullMethodName,
@@ -138,6 +185,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   false,
 			Idempotent:    true,
 			OpenWorldHint: true,
+			RequestType:   _BookstoreService_ListBooks_RequestType,
+			ResponseType:  _BookstoreService_ListBooks_ResponseType,
 		},
 		{
 			Method:        BookstoreService_DeleteBook_FullMethodName,
@@ -150,6 +199,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    false,
 			OpenWorldHint: false,
+			RequestType:   _BookstoreService_DeleteBook_RequestType,
+			ResponseType:  _BookstoreService_DeleteBook_ResponseType,
 		},
 		{
 			Method:        BookstoreService_UpdateBook_FullMethodName,
@@ -162,6 +213,8 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Destructive:   true,
 			Idempotent:    true,
 			OpenWorldHint: true,
+			RequestType:   _BookstoreService_UpdateBook_RequestType,
+			ResponseType:  _BookstoreService_UpdateBook_ResponseType,
 		},
 	},
 }

--- a/internal/mcpgw/mcpgw_imports.go
+++ b/internal/mcpgw/mcpgw_imports.go
@@ -19,6 +19,7 @@ type importTracker struct {
 	GRPC          bool
 	Context       bool
 	Proto         bool
+	Reflect       bool
 }
 
 type ImportAlias struct {

--- a/internal/mcpgw/mcpgw_methods.go
+++ b/internal/mcpgw/mcpgw_methods.go
@@ -11,12 +11,16 @@ import (
 	mcpgw_v1 "github.com/ductone/protoc-gen-mcpgw/mcpgw/v1"
 )
 
+
 type methodTemplateContext struct {
 	mcpgw_v1.MethodDesc
 	MethodHandlerName      string
 	DecoderHandlerName     string
 	InputSchemaHandlerName string
 	RequestType            string
+	RequestTypeName        string
+	ResponseType           string
+	ResponseTypeName       string
 	ServerName             string
 	MethodName             string
 	FullMethodName         string
@@ -38,6 +42,7 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 	ix.Proto = true
 	ix.Protojson = true
 	ix.GRPC = true
+	ix.Reflect = true
 
 	rv := &methodTemplateContext{
 		MethodDesc: mcpgw_v1.MethodDesc{
@@ -64,7 +69,16 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 			serviceShortName,
 			ctx.Name(method).String(),
 		),
-		RequestType: ctx.Name(method.Input()).String(),
+		RequestTypeName: fmt.Sprintf("_%s_%s_RequestType",
+			serviceShortName,
+			ctx.Name(method).String(),
+		),
+		ResponseTypeName: fmt.Sprintf("_%s_%s_ResponseType",
+			serviceShortName,
+			ctx.Name(method).String(),
+		),
+		RequestType:  ctx.Name(method.Input()).String(),
+		ResponseType: ctx.Name(method.Output()).String(),
 	}
 	return rv, nil
 }

--- a/internal/mcpgw/templates/header.tmpl
+++ b/internal/mcpgw/templates/header.tmpl
@@ -12,4 +12,5 @@ import (
 {{ if .Imports.Context }} context "context" {{ end }}
 {{ if .Imports.Proto }} proto "google.golang.org/protobuf/proto" {{ end }}
 {{ if .Imports.Protojson }} protojson "google.golang.org/protobuf/encoding/protojson" {{ end }}
+{{ if .Imports.Reflect }} reflect "reflect" {{ end }}
 )

--- a/internal/mcpgw/templates/service.tmpl
+++ b/internal/mcpgw/templates/service.tmpl
@@ -1,4 +1,12 @@
 
+// Reflected request/response types for each method
+var (
+{{- range .Methods }}
+	{{ .RequestTypeName }} = reflect.TypeOf((*{{ .RequestType }})(nil)).Elem()
+	{{ .ResponseTypeName }} = reflect.TypeOf((*{{ .ResponseType }})(nil)).Elem()
+{{- end }}
+)
+
 func RegisterMCP{{- .ServerName -}}(s mcpgw_v1.ServiceRegistrar, srv {{ .ServerName -}}) {
 	s.RegisterService(&mcpgw_desc_{{- .ServerName -}}, srv)
 }
@@ -19,6 +27,8 @@ var mcpgw_desc_{{- .ServerName -}} = mcpgw_v1.ServiceDesc{
             Destructive: {{ .Destructive -}},
             Idempotent: {{ .Idempotent -}},
             OpenWorldHint: {{ .OpenWorldHint -}},
+			RequestType: {{- .RequestTypeName -}},
+			ResponseType: {{- .ResponseTypeName -}},
 		},
 		{{- end }}
 	},

--- a/mcpgw/v1/descriptor.go
+++ b/mcpgw/v1/descriptor.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	reflect "reflect"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -15,7 +16,7 @@ type ServiceDesc struct {
 
 type methodHandler func(srv interface{}, ctx context.Context, dec func(proto.Message) error, interceptor grpc.UnaryServerInterceptor) (proto.Message, error)
 type decoderHandler func(ctx context.Context, input DecoderInput, out proto.Message) error
-type inputSchemaHandler func() (map[string]any)
+type inputSchemaHandler func() map[string]any
 
 type MethodDesc struct {
 	Method        string
@@ -28,6 +29,8 @@ type MethodDesc struct {
 	Destructive   bool
 	Idempotent    bool
 	OpenWorldHint bool
+	RequestType   reflect.Type
+	ResponseType  reflect.Type
 }
 
 type ServiceRegistrar interface {


### PR DESCRIPTION
By having references to the types, we can do better runtime type assertions when working with specific tool calls. 