### PR TITLE
Make method description generic for better runtime usage of request/response types

### DIFF
--- a/example/bookstore/v1/bookstore.pb.mcpgw.go
+++ b/example/bookstore/v1/bookstore.pb.mcpgw.go
@@ -18,8 +18,8 @@ func RegisterMCPBookstoreServiceServer(s mcpgw_v1.ServiceRegistrar, srv Bookstor
 var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 	Name:        "bookstore.v1.BookstoreService",
 	HandlerType: (*BookstoreServiceServer)(nil),
-	Methods: []*mcpgw_v1.MethodDesc{
-		{
+	Methods: []mcpgw_v1.MethodDescInterface{
+		&mcpgw_v1.MethodDesc[*ListShelvesRequest, *ListShelvesResponse]{
 			Method:        BookstoreService_ListShelves_FullMethodName,
 			Handler:       _BookstoreService_ListShelves_MCPGW_Handler,
 			Decoder:       _BookstoreService_ListShelves_MCPGW_Decoder,
@@ -31,7 +31,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    true,
 			OpenWorldHint: false,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*CreateShelfRequest, *CreateShelfResponse]{
 			Method:        BookstoreService_CreateShelf_FullMethodName,
 			Handler:       _BookstoreService_CreateShelf_MCPGW_Handler,
 			Decoder:       _BookstoreService_CreateShelf_MCPGW_Decoder,
@@ -43,7 +43,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    false,
 			OpenWorldHint: false,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*DeleteShelfRequest, *DeleteShelfResponse]{
 			Method:        BookstoreService_DeleteShelf_FullMethodName,
 			Handler:       _BookstoreService_DeleteShelf_MCPGW_Handler,
 			Decoder:       _BookstoreService_DeleteShelf_MCPGW_Decoder,
@@ -55,7 +55,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    false,
 			OpenWorldHint: false,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*ListGenresRequest, *ListGenresResponse]{
 			Method:        BookstoreService_ListGenres_FullMethodName,
 			Handler:       _BookstoreService_ListGenres_MCPGW_Handler,
 			Decoder:       _BookstoreService_ListGenres_MCPGW_Decoder,
@@ -67,7 +67,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    false,
 			OpenWorldHint: false,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*CreateGenreRequest, *CreateGenreResponse]{
 			Method:        BookstoreService_CreateGenre_FullMethodName,
 			Handler:       _BookstoreService_CreateGenre_MCPGW_Handler,
 			Decoder:       _BookstoreService_CreateGenre_MCPGW_Decoder,
@@ -79,7 +79,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    false,
 			OpenWorldHint: false,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*GetGenreRequest, *GetGenreResponse]{
 			Method:        BookstoreService_GetGenre_FullMethodName,
 			Handler:       _BookstoreService_GetGenre_MCPGW_Handler,
 			Decoder:       _BookstoreService_GetGenre_MCPGW_Decoder,
@@ -91,7 +91,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    false,
 			OpenWorldHint: false,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*DeleteGenreRequest, *DeleteGenreResponse]{
 			Method:        BookstoreService_DeleteGenre_FullMethodName,
 			Handler:       _BookstoreService_DeleteGenre_MCPGW_Handler,
 			Decoder:       _BookstoreService_DeleteGenre_MCPGW_Decoder,
@@ -103,7 +103,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    false,
 			OpenWorldHint: false,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*CreateBookRequest, *CreateBookResponse]{
 			Method:        BookstoreService_CreateBook_FullMethodName,
 			Handler:       _BookstoreService_CreateBook_MCPGW_Handler,
 			Decoder:       _BookstoreService_CreateBook_MCPGW_Decoder,
@@ -115,7 +115,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    true,
 			OpenWorldHint: true,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*GetBookRequest, *GetBookResponse]{
 			Method:        BookstoreService_GetBook_FullMethodName,
 			Handler:       _BookstoreService_GetBook_MCPGW_Handler,
 			Decoder:       _BookstoreService_GetBook_MCPGW_Decoder,
@@ -127,7 +127,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    true,
 			OpenWorldHint: true,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*ListBooksRequest, *ListBooksResponse]{
 			Method:        BookstoreService_ListBooks_FullMethodName,
 			Handler:       _BookstoreService_ListBooks_MCPGW_Handler,
 			Decoder:       _BookstoreService_ListBooks_MCPGW_Decoder,
@@ -139,7 +139,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    true,
 			OpenWorldHint: true,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*DeleteBookRequest, *DeleteBookResponse]{
 			Method:        BookstoreService_DeleteBook_FullMethodName,
 			Handler:       _BookstoreService_DeleteBook_MCPGW_Handler,
 			Decoder:       _BookstoreService_DeleteBook_MCPGW_Decoder,
@@ -151,7 +151,7 @@ var mcpgw_desc_BookstoreServiceServer = mcpgw_v1.ServiceDesc{
 			Idempotent:    false,
 			OpenWorldHint: false,
 		},
-		{
+		&mcpgw_v1.MethodDesc[*UpdateBookRequest, *UpdateBookResponse]{
 			Method:        BookstoreService_UpdateBook_FullMethodName,
 			Handler:       _BookstoreService_UpdateBook_MCPGW_Handler,
 			Decoder:       _BookstoreService_UpdateBook_MCPGW_Decoder,

--- a/example/bookstore/v1/bookstore_test.go
+++ b/example/bookstore/v1/bookstore_test.go
@@ -667,47 +667,6 @@ func TestConvertToConcreteType(t *testing.T) {
 		_, ok = newResp.(*v1.CreateGenreResponse)
 		assert.True(t, ok, "New response should be CreateGenreResponse")
 	})
-
-	t.Run("Assert_Methods", func(t *testing.T) {
-		methodDesc := mockRegistrar.methodDescs["/bookstore.v1.BookstoreService/CreateGenre"]
-		require.NotNil(t, methodDesc, "Method descriptor for CreateGenre should be registered")
-
-		// Test AssertRequestType method
-		originalReq := &v1.CreateGenreRequest{}
-		originalReq.SetName("Test Genre")
-
-		convertedReq, err := methodDesc.AssertRequestType(context.Background(), originalReq)
-		assert.NoError(t, err, "Should successfully assert request type")
-		assert.NotNil(t, convertedReq, "Converted request should not be nil")
-
-		genreReq, ok := convertedReq.(*v1.CreateGenreRequest)
-		assert.True(t, ok, "Should be convertible to CreateGenreRequest")
-		assert.Equal(t, "Test Genre", genreReq.GetName(), "Name should be preserved")
-
-		// Test AssertResponseType method
-		originalResp := &v1.CreateGenreResponse{}
-		genre := &v1.Genre{}
-		genre.SetId(456)
-		genre.SetName("Test Genre")
-		originalResp.SetGenre(genre)
-
-		convertedResp, err := methodDesc.AssertResponseType(context.Background(), originalResp)
-		assert.NoError(t, err, "Should successfully assert response type")
-		assert.NotNil(t, convertedResp, "Converted response should not be nil")
-
-		genreResp, ok := convertedResp.(*v1.CreateGenreResponse)
-		assert.True(t, ok, "Should be convertible to CreateGenreResponse")
-		assert.Equal(t, int64(456), genreResp.GetGenre().GetId(), "ID should be preserved")
-
-		// Test with wrong types
-		wrongReq := &v1.CreateBookRequest{}
-		_, err = methodDesc.AssertRequestType(context.Background(), wrongReq)
-		assert.Error(t, err, "Should fail to assert wrong request type")
-
-		wrongResp := &v1.CreateBookResponse{}
-		_, err = methodDesc.AssertResponseType(context.Background(), wrongResp)
-		assert.Error(t, err, "Should fail to assert wrong response type")
-	})
 }
 
 // mockBookstoreServer is a mock implementation of BookstoreServiceServer

--- a/internal/mcpgw/mcpgw_methods.go
+++ b/internal/mcpgw/mcpgw_methods.go
@@ -7,16 +7,21 @@ import (
 
 	pgs "github.com/lyft/protoc-gen-star/v2"
 	pgsgo "github.com/lyft/protoc-gen-star/v2/lang/go"
-
-	mcpgw_v1 "github.com/ductone/protoc-gen-mcpgw/mcpgw/v1"
 )
 
 type methodTemplateContext struct {
-	mcpgw_v1.MethodDesc
+	Method                 string
+	Title                  string
+	Description            string
+	ReadOnlyHint           bool
+	Destructive            bool
+	Idempotent             bool
+	OpenWorldHint          bool
 	MethodHandlerName      string
 	DecoderHandlerName     string
 	InputSchemaHandlerName string
 	RequestType            string
+	ResponseType           string
 	ServerName             string
 	MethodName             string
 	FullMethodName         string
@@ -40,15 +45,13 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 	ix.GRPC = true
 
 	rv := &methodTemplateContext{
-		MethodDesc: mcpgw_v1.MethodDesc{
-			Method:        methodFullName,
-			Title:         mext.GetTitle(),
-			Description:   mext.GetDescription(),
-			ReadOnlyHint:  mext.GetReadOnlyHint(),
-			Destructive:   mext.GetDestructiveHint(),
-			Idempotent:    mext.GetIdempotentHint(),
-			OpenWorldHint: mext.GetOpenWorldHint(),
-		},
+		Method:         methodFullName,
+		Title:          mext.GetTitle(),
+		Description:    mext.GetDescription(),
+		ReadOnlyHint:   mext.GetReadOnlyHint(),
+		Destructive:    mext.GetDestructiveHint(),
+		Idempotent:     mext.GetIdempotentHint(),
+		OpenWorldHint:  mext.GetOpenWorldHint(),
 		ServerName:     ctx.ServerName(service).String(),
 		MethodName:     ctx.Name(method).String(),
 		FullMethodName: methodFullName,
@@ -64,7 +67,8 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 			serviceShortName,
 			ctx.Name(method).String(),
 		),
-		RequestType: ctx.Name(method.Input()).String(),
+		RequestType:  ctx.Name(method.Input()).String(),
+		ResponseType: ctx.Name(method.Output()).String(),
 	}
 	return rv, nil
 }

--- a/internal/mcpgw/templates/service.tmpl
+++ b/internal/mcpgw/templates/service.tmpl
@@ -1,4 +1,3 @@
-
 func RegisterMCP{{- .ServerName -}}(s mcpgw_v1.ServiceRegistrar, srv {{ .ServerName -}}) {
 	s.RegisterService(&mcpgw_desc_{{- .ServerName -}}, srv)
 }
@@ -6,9 +5,9 @@ func RegisterMCP{{- .ServerName -}}(s mcpgw_v1.ServiceRegistrar, srv {{ .ServerN
 var mcpgw_desc_{{- .ServerName -}} = mcpgw_v1.ServiceDesc{
 	Name: "{{ .FullyQualifiedName -}}",
 	HandlerType: (*{{- .ServerName -}})(nil),
-	Methods: []*mcpgw_v1.MethodDesc{
+	Methods: []mcpgw_v1.MethodDescInterface{
 		{{- range .Methods }}
-		{
+		&mcpgw_v1.MethodDesc[*{{ .RequestType -}}, *{{ .ResponseType -}}]{
 			Method: {{- .Method -}},
 			Handler: {{ .MethodHandlerName -}},
 			Decoder: {{ .DecoderHandlerName -}},

--- a/mcpgw/v1/descriptor.go
+++ b/mcpgw/v1/descriptor.go
@@ -2,6 +2,9 @@ package v1
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"reflect"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -10,16 +13,17 @@ import (
 type ServiceDesc struct {
 	Name        string
 	HandlerType interface{}
-	Methods     []*MethodDesc
+	Methods     []MethodDescInterface
 }
 
-type methodHandler func(srv interface{}, ctx context.Context, dec func(proto.Message) error, interceptor grpc.UnaryServerInterceptor) (proto.Message, error)
+type methodHandler[TReq, TResp proto.Message] func(srv interface{}, ctx context.Context, dec func(proto.Message) error, interceptor grpc.UnaryServerInterceptor) (proto.Message, error)
 type decoderHandler func(ctx context.Context, input DecoderInput, out proto.Message) error
-type inputSchemaHandler func() (map[string]any)
+type inputSchemaHandler func() map[string]any
 
-type MethodDesc struct {
+// MethodDesc is a generic type that captures the specific request and response types
+type MethodDesc[TReq, TResp proto.Message] struct {
 	Method        string
-	Handler       methodHandler
+	Handler       methodHandler[TReq, TResp]
 	Decoder       decoderHandler
 	InputSchema   inputSchemaHandler
 	Title         string
@@ -28,6 +32,161 @@ type MethodDesc struct {
 	Destructive   bool
 	Idempotent    bool
 	OpenWorldHint bool
+}
+
+// MethodDescInterface provides a common interface for all MethodDesc types
+type MethodDescInterface interface {
+	GetMethod() string
+	GetHandler() func(srv interface{}, ctx context.Context, dec func(proto.Message) error, interceptor grpc.UnaryServerInterceptor) (proto.Message, error)
+	GetDecoder() decoderHandler
+	GetInputSchema() inputSchemaHandler
+	GetTitle() string
+	GetDescription() string
+	GetReadOnlyHint() bool
+	GetDestructive() bool
+	GetIdempotent() bool
+	GetOpenWorldHint() bool
+	AssertRequestType(ctx context.Context, in proto.Message) (proto.Message, error)
+	AssertResponseType(ctx context.Context, in proto.Message) (proto.Message, error)
+
+	// Get concrete types at runtime
+	GetRequestType() reflect.Type
+	GetResponseType() reflect.Type
+	CreateRequest() proto.Message
+	CreateResponse() proto.Message
+}
+
+// Implement MethodDescInterface for MethodDesc[TReq, TResp]
+func (md *MethodDesc[TReq, TResp]) GetMethod() string {
+	return md.Method
+}
+
+func (md *MethodDesc[TReq, TResp]) GetHandler() func(srv interface{}, ctx context.Context, dec func(proto.Message) error, interceptor grpc.UnaryServerInterceptor) (proto.Message, error) {
+	return md.Handler
+}
+
+func (md *MethodDesc[TReq, TResp]) GetDecoder() decoderHandler {
+	return md.Decoder
+}
+
+func (md *MethodDesc[TReq, TResp]) GetInputSchema() inputSchemaHandler {
+	return md.InputSchema
+}
+
+func (md *MethodDesc[TReq, TResp]) GetTitle() string {
+	return md.Title
+}
+
+func (md *MethodDesc[TReq, TResp]) GetDescription() string {
+	return md.Description
+}
+
+func (md *MethodDesc[TReq, TResp]) GetReadOnlyHint() bool {
+	return md.ReadOnlyHint
+}
+
+func (md *MethodDesc[TReq, TResp]) GetDestructive() bool {
+	return md.Destructive
+}
+
+func (md *MethodDesc[TReq, TResp]) GetIdempotent() bool {
+	return md.Idempotent
+}
+
+func (md *MethodDesc[TReq, TResp]) GetOpenWorldHint() bool {
+	return md.OpenWorldHint
+}
+
+// AssertRequestType converts a proto.Message to the specific request type for this method
+func (md *MethodDesc[TReq, TResp]) AssertRequestType(ctx context.Context, in proto.Message) (proto.Message, error) {
+	if in == nil {
+		return nil, errors.New("request cannot be nil")
+	}
+
+	// Try to convert to the specific type
+	if req, ok := in.(TReq); ok {
+		return req, nil
+	}
+
+	return nil, fmt.Errorf("expected request type %T, got %T", (*TReq)(nil), in)
+}
+
+// AssertResponseType converts a proto.Message to the specific response type for this method
+func (md *MethodDesc[TReq, TResp]) AssertResponseType(ctx context.Context, in proto.Message) (proto.Message, error) {
+	if in == nil {
+		return nil, errors.New("response cannot be nil")
+	}
+
+	// Try to convert to the specific type
+	if resp, ok := in.(TResp); ok {
+		return resp, nil
+	}
+
+	return nil, fmt.Errorf("expected response type %T, got %T", (*TResp)(nil), in)
+}
+
+// GetRequestType returns the reflect.Type of the request type
+func (md *MethodDesc[TReq, TResp]) GetRequestType() reflect.Type {
+	// Get the type of TReq (which is a pointer type)
+	return reflect.TypeOf((*TReq)(nil)).Elem()
+}
+
+// GetResponseType returns the reflect.Type of the response type
+func (md *MethodDesc[TReq, TResp]) GetResponseType() reflect.Type {
+	// Get the type of TResp (which is a pointer type)
+	return reflect.TypeOf((*TResp)(nil)).Elem()
+}
+
+// CreateRequest creates a new instance of the request type
+func (md *MethodDesc[TReq, TResp]) CreateRequest() proto.Message {
+	// TReq is a pointer type, so get the element type and create a new instance
+	ptrType := reflect.TypeOf((*TReq)(nil)).Elem() // e.g., *v1.CreateGenreRequest
+	val := reflect.New(ptrType.Elem()).Interface() // new(v1.CreateGenreRequest)
+	return val.(proto.Message)
+}
+
+// CreateResponse creates a new instance of the response type
+func (md *MethodDesc[TReq, TResp]) CreateResponse() proto.Message {
+	ptrType := reflect.TypeOf((*TResp)(nil)).Elem()
+	val := reflect.New(ptrType.Elem()).Interface()
+	return val.(proto.Message)
+}
+
+// Helper function to convert proto.Message to concrete type using reflection
+func ConvertToConcreteType(method MethodDescInterface, in proto.Message, isRequest bool) (proto.Message, error) {
+	if in == nil {
+		return nil, errors.New("input cannot be nil")
+	}
+
+	var expectedType reflect.Type
+	if isRequest {
+		expectedType = method.GetRequestType()
+	} else {
+		expectedType = method.GetResponseType()
+	}
+
+	// Check if the input is already the correct type
+	if reflect.TypeOf(in) == expectedType {
+		return in, nil
+	}
+
+	// Try to convert using reflection
+	val := reflect.ValueOf(in)
+	if val.Type() == expectedType {
+		return in, nil
+	}
+
+	// If it's a pointer to the correct type, return it
+	if val.Type().Elem() == expectedType.Elem() {
+		return in, nil
+	}
+
+	typeName := "response"
+	if isRequest {
+		typeName = "request"
+	}
+
+	return nil, fmt.Errorf("expected %s type %v, got %v", typeName, expectedType, reflect.TypeOf(in))
 }
 
 type ServiceRegistrar interface {

--- a/mcpgw/v1/descriptor.go
+++ b/mcpgw/v1/descriptor.go
@@ -46,8 +46,6 @@ type MethodDescInterface interface {
 	GetDestructive() bool
 	GetIdempotent() bool
 	GetOpenWorldHint() bool
-	AssertRequestType(ctx context.Context, in proto.Message) (proto.Message, error)
-	AssertResponseType(ctx context.Context, in proto.Message) (proto.Message, error)
 
 	// Get concrete types at runtime
 	GetRequestType() reflect.Type
@@ -95,34 +93,6 @@ func (md *MethodDesc[TReq, TResp]) GetIdempotent() bool {
 
 func (md *MethodDesc[TReq, TResp]) GetOpenWorldHint() bool {
 	return md.OpenWorldHint
-}
-
-// AssertRequestType converts a proto.Message to the specific request type for this method
-func (md *MethodDesc[TReq, TResp]) AssertRequestType(ctx context.Context, in proto.Message) (proto.Message, error) {
-	if in == nil {
-		return nil, errors.New("request cannot be nil")
-	}
-
-	// Try to convert to the specific type
-	if req, ok := in.(TReq); ok {
-		return req, nil
-	}
-
-	return nil, fmt.Errorf("expected request type %T, got %T", (*TReq)(nil), in)
-}
-
-// AssertResponseType converts a proto.Message to the specific response type for this method
-func (md *MethodDesc[TReq, TResp]) AssertResponseType(ctx context.Context, in proto.Message) (proto.Message, error) {
-	if in == nil {
-		return nil, errors.New("response cannot be nil")
-	}
-
-	// Try to convert to the specific type
-	if resp, ok := in.(TResp); ok {
-		return resp, nil
-	}
-
-	return nil, fmt.Errorf("expected response type %T, got %T", (*TResp)(nil), in)
 }
 
 // GetRequestType returns the reflect.Type of the request type

--- a/mcpgw/v1/mcp_bridge.go
+++ b/mcpgw/v1/mcp_bridge.go
@@ -19,11 +19,11 @@ const (
 	contextKeyMethodDesc = contextKey("methodDesc")
 )
 
-func MethodDescContext(ctx context.Context) *MethodDesc {
-	return ctx.Value(contextKeyMethodDesc).(*MethodDesc)
+func MethodDescContext(ctx context.Context) MethodDescInterface {
+	return ctx.Value(contextKeyMethodDesc).(MethodDescInterface)
 }
 
-func NewMethodDescContext(ctx context.Context, methodDesc *MethodDesc) context.Context {
+func NewMethodDescContext(ctx context.Context, methodDesc MethodDescInterface) context.Context {
 	return context.WithValue(ctx, contextKeyMethodDesc, methodDesc)
 }
 


### PR DESCRIPTION
This should allow us to use reflection to work with the concrete request/response types.